### PR TITLE
Fix a11y assertion based on the new standard

### DIFF
--- a/docs/pages/components/ComboBox.test.js
+++ b/docs/pages/components/ComboBox.test.js
@@ -26,7 +26,7 @@ describe('<ComboBox />', () => {
       </div>,
     );
 
-    const textbox = screen.getByRole('textbox');
+    const textbox = screen.getByRole('combobox');
 
     fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // open the popup
     fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // focus the first option


### PR DESCRIPTION
Since WAI-ARIA 1.2 it’s no longer `textbox` but `combobox`. This has already been fixed in the core https://github.com/mui/material-ui/pull/30601/files. So far, I got two candidates that used the challenge that raised this issue.